### PR TITLE
Test CI with newer versions of Python

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7]
+        python-version: [3.7, 3.8, 3.9]
     runs-on: ${{ matrix.platform }}
 
     steps:


### PR DESCRIPTION
Py 3.8 and 3.9. Drop 3.6 because mac OS latest does not support it natively any more