### PR TITLE
M2M fix missing keys in comm_scopes json.

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -57,7 +57,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .
-        python -c 'from ete import NCBITaxa; ncbi = NCBITaxa()'
+        python -c 'from ete3 import NCBITaxa; ncbi = NCBITaxa()'
     - name: Test with pytest
       run: |
         pip install pytest

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -57,6 +57,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .
+        python -c 'from ete import NCBITaxa; ncbi = NCBITaxa()'
     - name: Test with pytest
       run: |
         pip install pytest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# Metage2Metabo v1.6.1 (2024-03-28)
+
+## Fix
+
+* Fix an issue with host keys ("host_prodtargets", "host_scope", "comhost_scope" and "host_unprodtargets") not appearing in `comm_scopes.json` file. But these keys used the old behavior of Metage2Metabo (possible unproducible seeds are contained in them). Host handling by Metage2Metabo will be modified in a future release.
+
 # Metage2Metabo v1.6.0 (2024-03-01)
 
 WARNING: change for individual and community scopes:

--- a/metage2metabo/__init__.py
+++ b/metage2metabo/__init__.py
@@ -12,6 +12,6 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>
 
-__version__ = '1.6.0'
+__version__ = '1.6.1'
 """ version of the package
 """ 

--- a/metage2metabo/m2m/community_scope.py
+++ b/metage2metabo/m2m/community_scope.py
@@ -134,6 +134,11 @@ def comm_scope_run(instance, output_dir, host_mn=None):
         scopes_results = run_scopes(lp_instance_file=instance)
         com_scope_dict = {}
         com_scope_dict['com_scope'] = scopes_results['com_scope']
+        com_scope_dict['host_prodtargets'] = scopes_results['host_prodtargets']
+        com_scope_dict['host_scope'] = scopes_results['host_scope']
+        com_scope_dict['comhost_scope'] = scopes_results['comhost_scope']
+        com_scope_dict['host_unprodtargets'] = scopes_results['host_unprodtargets']
+
         contributions_of_microbes = None
         logger.info('The computation of the community scope with a host is of limited functionality. It will not highlight the contribution of each microbe to the community scope. Additionally, the producibility of seeds by the microbes will not be computed. Consider running the community scope without a host (i.e. all metabolic networks, including the host, in the same directory) to get the full functionality of the community scope. \n')
         with open(com_scopes_path, 'w') as dumpfile:

--- a/test/test_tiny_toy_metacom.py
+++ b/test/test_tiny_toy_metacom.py
@@ -522,6 +522,16 @@ def test_m2m_metacom_tiny_toy_host():
     # ensure the newly producible targets are ok
     assert set(mincom['producible']) == PROD_TARGETS
 
+    comm_scopes_file = os.path.join(*[respath, 'community_analysis', 'comm_scopes.json'])
+    with open(comm_scopes_file, 'r') as json_cdata:
+        comm_scopes = json.load(json_cdata)
+
+    # Check host keys in comm_scopes json.
+    assert len(comm_scopes['com_scope']) == 13
+    assert set(comm_scopes['host_unprodtargets']) == set(['M_F_c', 'M_H_c', 'M_foo_c', 'M_C_c'])
+    # Host scope = old behavior, seed in scope.
+    assert set(comm_scopes['host_scope']) == set(['M_S1_c', 'M_S2_c'])
+
     # clean
     # Due to unstable behaviour of os.unlink on Windows, do not delete the file.
     # Refer to: https://github.com/python/cpython/issues/109608


### PR DESCRIPTION
## Fix

* Fix an issue with host keys ("host_prodtargets", "host_scope", "comhost_scope" and "host_unprodtargets") not appearing in `comm_scopes.json` file. But these keys used the old behavior of Metage2Metabo (possible unproducible seeds are contained in them). Host handling by Metage2Metabo will be modified in a future release.